### PR TITLE
The version number was not being split

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1258,7 +1258,7 @@ jobs:
       run: |
         cd WISE_Application/WISE/include
         $TOTAL_VERSION="${{ steps.version-numbers.outputs.prometheus_version }}"
-        $SPLIT_VERSION=$TOTAL_VERSION.Split(".-")
+        $SPLIT_VERSION=$TOTAL_VERSION.Split(".-".ToCharArray())
         echo "#ifndef VER_STRINGIFY2" > prom_vers.h
         echo "#define VER_STRINGIFY2(ver) #ver" >> prom_vers.h
         echo "#endif" >> prom_vers.h


### PR DESCRIPTION
A breaking change with the split method in PowerShell 7 stopped the version number from being split apart into its parts correctly when generating the version file.