### PR TITLE
Incorrect permissions on Java library files in test action

### DIFF
--- a/.github/workflows/bugTest_182.yml
+++ b/.github/workflows/bugTest_182.yml
@@ -29,7 +29,14 @@ jobs:
       - name: unzip the builder
         run: ls -lha;cd builder; ls -lha; unzip *.zip
       - name: install the builder
-        run: ls -lha;cd builder;chmod 777 WISE_Builder.jar; ls -lha; sudo cp -f WISE_Builder.jar /usr/bin/; sudo cp -Rf WISE_Builder_lib/ /usr/bin/
+        run: |
+          ls -lha
+          cd builder
+          chmod 777 WISE_Builder.jar
+          chmod -R 777 WISE_Builder_lib/
+          ls -lha
+          sudo cp -f WISE_Builder.jar /usr/bin/
+          sudo cp -Rf WISE_Builder_lib/ /usr/bin/
    
       - name: Install JDK 17 and run builder
         uses: actions/setup-java@v3


### PR DESCRIPTION
The Builder files are unzipped with 0000 permissions on all files except for the WISE_Builder_lib folder which has 0775. The permission on the main jar file (WISE_Builder.jar) was being updated but the permissions on the dependencies were not. This stopped Java from being able to load them at runtime which caused a ClassNotFoundException on the first class that Java came across that is contained in those libraries, which happened to be JAXBException. A recursive permission update on the WISE_Builder_lib directory should get it running for WISE-Developers/Project_Issues#182.