### PR TITLE
Move the export driver list to paths/strings

### DIFF
--- a/WISE/cpp/Simulation.cpp
+++ b/WISE/cpp/Simulation.cpp
@@ -881,7 +881,8 @@ void exportVectors(const int w_export_i, const int w_export_cnt, worker_struct* 
 					std::string ext = fs::path(csPath).extension().string();
 					if (ext.length() == 0)
 						csPath += ".gpkg"s;
-					auto [driver_name, projection_name] = ws->sp->guessDriverNameFromFilename(csPath.c_str());
+					std::filesystem::path fname(csPath);
+					auto [driver_name, projection_name] = ws->sp->guessDriverNameFromFilename(fname);
 
 					USHORT flags = 0;
 					if (out.activePerimeters)			flags |= SCENARIO_EXPORT_SUBSET_ACTIVE;
@@ -2253,13 +2254,13 @@ void SPARCS_P::UpdateJob(const std::vector<std::string>& topic, std::vector<JSON
 }
 
 
-std::tuple<const char*, const char*> SPARCS_P::guessDriverNameFromFilename(const char *filename)
+std::tuple<std::string_view, std::string> SPARCS_P::guessDriverNameFromFilename(std::filesystem::path &filename)
 {
-	std::string ext = fs::path(filename).extension().string();
+	std::string ext = filename.extension().string();
 	const char *driver_name;
 	const char* projection_name = "";
-    if (boost::iequals(ext, ".SHP"))	driver_name = "ESRI Shapefile";
-	else if (boost::iequals(ext, ".GPKG"))	driver_name = "GeoPackage vector";
+    if (boost::iequals(ext, ".SHP"))		driver_name = "ESRI Shapefile";
+	else if (boost::iequals(ext, ".GPKG"))	driver_name = "GPKG";
 	else if (boost::iequals(ext, ".TAB"))	driver_name = "MapInfo File";
 	else if (boost::iequals(ext, ".DAT"))	driver_name = "MapInfo File";
 	else if (boost::iequals(ext, ".MAP"))	driver_name = "MapInfo File";

--- a/WISE/cpp/Stats.cpp
+++ b/WISE/cpp/Stats.cpp
@@ -1643,8 +1643,9 @@ HRESULT exportAssetStats(UnitConversion& unitConversion, Project::CWFGMProject* 
 							builder->globalStats.arrivalCount++;
 
 							if (stats.criticalPathFilename.length()) {
-								auto [driver_name, projection_name] = sp->guessDriverNameFromFilename(stats.criticalPathFilename.c_str());
-								s->ExportCriticalPath(asset, j, 0, driver_name, projection_name, stats.criticalPathFilename.c_str());
+								std::filesystem::path fname(stats.criticalPathFilename);
+								auto [driver_name, projection_name] = sp->guessDriverNameFromFilename(fname);
+								s->ExportCriticalPath(asset, j, 0, driver_name, projection_name, fname);
 							}
 						}
 					}

--- a/WISE/include/WISE.h
+++ b/WISE/include/WISE.h
@@ -81,7 +81,7 @@ public:
 	MinListTempl<class SimMessage> m_list;
 
 	std::unique_ptr<ICWFGM_FWI>	m_fwi;
-	std::tuple<const char*, const char*> guessDriverNameFromFilename(const char *filename);
+	std::tuple<std::string_view, std::string> guessDriverNameFromFilename(std::filesystem::path& filename);
 
 	HRESULT Initialize_SPARCS_P();
 	virtual HRESULT ConnectMQTT(bool justSummary) { return ConnectMQTTProto(justSummary); }

--- a/WISE_Project/cpp/CWFGMProject.cpp
+++ b/WISE_Project/cpp/CWFGMProject.cpp
@@ -4285,19 +4285,15 @@ HRESULT Project::CWFGMProject::PrintReportTxt(const TCHAR *szPath, const PrintRe
 }
 
 #include "PermissibleVectorReadDrivers.h"
-const char *Project::CWFGMProject::m_permissibleVectorReadDrivers[] = GDAL_READ_DRIVERS;
-std::vector<std::string> Project::CWFGMProject::m_permissibleVectorReadDriversSA;
+std::vector<std::string_view> Project::CWFGMProject::m_permissibleVectorReadDriversSA;
 
 class StaticInitializer
 {
 public:
 	StaticInitializer()
 	{
-		for (int iii = 0; iii < GDAL_READ_DRIVERS_LENGTH; iii++)
-		{
-			std::string c(Project::CWFGMProject::m_permissibleVectorReadDrivers[iii]);
-			Project::CWFGMProject::m_permissibleVectorReadDriversSA.push_back(c);
-		}
+		for (int iii = 0; iii < permissibleVectorReadDrivers.size(); iii++)
+			Project::CWFGMProject::m_permissibleVectorReadDriversSA.push_back(permissibleVectorReadDrivers[iii]);
 	}
 };
 static StaticInitializer init;

--- a/WISE_Project/cpp/Fire.cpp
+++ b/WISE_Project/cpp/Fire.cpp
@@ -88,9 +88,9 @@ HRESULT Project::StdFire::SetIgnition(std::uint32_t index, std::uint16_t ignitio
 }
 
 
-HRESULT Project::StdFire::ImportIgnition(const std::string &file_name, const std::vector<std::string> *pd)
+HRESULT Project::StdFire::ImportIgnition(const std::filesystem::path &file_name, const std::vector<std::string_view> &permissible_drivers)
 {
-	return m_fire->ImportIgnition(file_name, pd, nullptr);
+	return m_fire->ImportIgnition(file_name, permissible_drivers, nullptr);
 }
 
 
@@ -100,7 +100,7 @@ HRESULT Project::StdFire::ImportIgnitionWFS(const std::string &server, const std
 }
 
 
-HRESULT Project::StdFire::ExportIgnition(const std::string &driver_name, const std::string &export_projection, const std::string &file_name)
+HRESULT Project::StdFire::ExportIgnition(std::string_view driver_name, const std::string &export_projection, const std::filesystem::path &file_name)
 {
 	return m_fire->ExportIgnition(driver_name, export_projection, file_name);
 }

--- a/WISE_Project/cpp/FireCollection.proto.cpp
+++ b/WISE_Project/cpp/FireCollection.proto.cpp
@@ -115,9 +115,8 @@ auto Project::Fire::deserialize(const google::protobuf::Message& proto, std::sha
 
 		if (fire->has_ignition())
 		{
-			std::vector<std::string> drivers = GDAL_READ_DRIVERS;
 			SerializeIgnitionData data;
-			data.permissible_drivers = &drivers;
+			data.permissible_drivers = &Project::CWFGMProject::m_permissibleVectorReadDriversSA;
 			ISerializeProto* sp = m_fire.get();
 			if (!sp->deserialize(fire->ignition(), v, "ignition", &data))
 			{
@@ -183,9 +182,8 @@ auto Project::Fire::deserialize(const google::protobuf::Message& proto, std::sha
 		if (fire->has_symbol())
 			m_symbol = fire->symbol();
 
-		std::vector<std::string> drivers = GDAL_READ_DRIVERS;
 		SerializeIgnitionData data;
-		data.permissible_drivers = &drivers;
+		data.permissible_drivers = &Project::CWFGMProject::m_permissibleVectorReadDriversSA;
 		ISerializeProto* sp = m_fire.get();
 		if (!sp->deserialize(*fire, v, "ignition", &data))
 		{

--- a/WISE_Project/cpp/GridFilter.proto.cpp
+++ b/WISE_Project/cpp/GridFilter.proto.cpp
@@ -498,7 +498,8 @@ auto Project::PolyReplaceGridFilter::deserialize(const google::protobuf::Message
 #endif
 		{
 			HRESULT hr;
-			if (FAILED(hr = ImportPolygons(filter->filename().value(), &CWFGMProject::m_permissibleVectorReadDriversSA))) {
+			std::filesystem::path fname(filter->filename().value());
+			if (FAILED(hr = ImportPolygons(fname, CWFGMProject::m_permissibleVectorReadDriversSA))) {
 				if (v) {
 					switch (hr) {
 					case E_POINTER:						v->add_child_validation("string", "shape.filename", validation::error_level::SEVERE, validation::id::e_pointer, filter->filename().value()); break;
@@ -598,7 +599,8 @@ auto Project::PolyReplaceGridFilter::deserialize(const google::protobuf::Message
 #endif
 			{
 				HRESULT hr;
-				if (FAILED(hr = ImportPolygons(filter->filename(), &CWFGMProject::m_permissibleVectorReadDriversSA))) {
+				std::filesystem::path fname(filter->filename());
+				if (FAILED(hr = ImportPolygons(fname, CWFGMProject::m_permissibleVectorReadDriversSA))) {
 					if (v) {
 						switch (hr) {
 						case E_POINTER:						v->add_child_validation("string", "shape.filename", validation::error_level::SEVERE, validation::id::e_pointer, filter->filename()); break;
@@ -765,7 +767,8 @@ auto Project::StaticVector::deserialize(const google::protobuf::Message& proto, 
 			if (fs::exists(fs::relative(vector->filename())))
 #endif
 			{
-				if (FAILED(hr = ImportPolylines(vector->file().filename(), &CWFGMProject::m_permissibleVectorReadDriversSA))) {
+				std::filesystem::path fname(vector->file().filename());
+				if (FAILED(hr = ImportPolylines(fname, CWFGMProject::m_permissibleVectorReadDriversSA))) {
 					if (v) {
 						switch (hr) {
 						case E_POINTER:						v->add_child_validation("string", "data.filename", validation::error_level::SEVERE, validation::id::e_pointer, vector->file().filename()); break;
@@ -808,7 +811,8 @@ auto Project::StaticVector::deserialize(const google::protobuf::Message& proto, 
 			if (fs::exists(fs::relative(file.filename())))
 #endif
 			{
-				if (FAILED(hr = ImportPolylines(file.filename(), &CWFGMProject::m_permissibleVectorReadDriversSA))) {
+				std::filesystem::path fname(file.filename());
+				if (FAILED(hr = ImportPolylines(fname, CWFGMProject::m_permissibleVectorReadDriversSA))) {
 					if (v2) {
 						switch (hr) {
 						case E_POINTER:						v2->add_child_validation("string", "filename", validation::error_level::SEVERE, validation::id::e_pointer, vector->file().filename()); break;
@@ -932,7 +936,8 @@ auto Project::StaticVector::deserialize(const google::protobuf::Message& proto, 
 				if (fs::exists(fs::relative(vector->filename())))
 #endif
 				{
-					if (FAILED(hr = ImportPolylines(vector->filename(), &CWFGMProject::m_permissibleVectorReadDriversSA))) {
+					std::filesystem::path fname(vector->filename());
+					if (FAILED(hr = ImportPolylines(fname, CWFGMProject::m_permissibleVectorReadDriversSA))) {
 						if (v2) {
 							switch (hr) {
 							case E_POINTER:						v2->add_child_validation("string", "filename", validation::error_level::SEVERE, validation::id::e_pointer, vector->filename()); break;
@@ -1114,7 +1119,8 @@ auto Project::Asset::deserialize(const google::protobuf::Message& proto, std::sh
 #endif
 			{
 				HRESULT hr;
-				if (FAILED(hr = ImportPolylines(file.filename(), CWFGMProject::m_permissibleVectorReadDriversSA))) {
+				std::filesystem::path fname(file.filename());
+				if (FAILED(hr = ImportPolylines(fname, CWFGMProject::m_permissibleVectorReadDriversSA))) {
 					switch (hr) {
 					case E_POINTER:							if (v) v->add_child_validation("string", "data.filename", validation::error_level::SEVERE, validation::id::e_pointer, file.filename()); break;
 					case E_INVALIDARG:						if (v) v->add_child_validation("string", "data.filename", validation::error_level::SEVERE, validation::id::e_invalidarg, file.filename()); break;
@@ -1237,7 +1243,8 @@ auto Project::Asset::deserialize(const google::protobuf::Message& proto, std::sh
 #endif
 				{
 					HRESULT hr;
-					if (FAILED(hr = ImportPolylines(asset->filename(), CWFGMProject::m_permissibleVectorReadDriversSA))) {
+					std::filesystem::path fname(asset->filename());
+					if (FAILED(hr = ImportPolylines(fname, CWFGMProject::m_permissibleVectorReadDriversSA))) {
 						switch (hr) {
 						case E_POINTER:							if (v) v->add_child_validation("string", "data.filename", validation::error_level::SEVERE, validation::id::e_pointer, asset->filename()); break;
 						case E_INVALIDARG:						if (v) v->add_child_validation("string", "data.filename", validation::error_level::SEVERE, validation::id::e_invalidarg, asset->filename()); break;
@@ -1408,7 +1415,8 @@ Project::Target* Project::Target::deserialize(const google::protobuf::Message& p
 			if (std::filesystem::exists(std::filesystem::relative(file.filename())))
 			{
 				HRESULT hr;
-				if (FAILED(hr = ImportPointSet(file.filename(), CWFGMProject::m_permissibleVectorReadDriversSA))) {
+				std::filesystem::path fname(file.filename());
+				if (FAILED(hr = ImportPointSet(fname, CWFGMProject::m_permissibleVectorReadDriversSA))) {
 					switch (hr) {
 					case E_POINTER:							if (v) v->add_child_validation("string", "data.filename", validation::error_level::SEVERE, validation::id::e_pointer, file.filename()); break;
 					case E_INVALIDARG:						if (v) v->add_child_validation("string", "data.filename", validation::error_level::SEVERE, validation::id::e_invalidarg, file.filename()); break;
@@ -1504,7 +1512,8 @@ Project::Target* Project::Target::deserialize(const google::protobuf::Message& p
 				if (std::filesystem::exists(std::filesystem::relative(target->filename())))
 				{
 					HRESULT hr;
-					if (FAILED(hr = ImportPointSet(target->filename(), CWFGMProject::m_permissibleVectorReadDriversSA))) {
+					std::filesystem::path fname(target->filename());
+					if (FAILED(hr = ImportPointSet(fname, CWFGMProject::m_permissibleVectorReadDriversSA))) {
 						switch (hr) {
 						case E_POINTER:							if (v) v->add_child_validation("string", "data.filename", validation::error_level::SEVERE, validation::id::e_pointer, target->filename()); break;
 						case E_INVALIDARG:						if (v) v->add_child_validation("string", "data.filename", validation::error_level::SEVERE, validation::id::e_invalidarg, target->filename()); break;
@@ -2038,7 +2047,6 @@ auto Project::GridFilterCollection::deserialize(const google::protobuf::Message&
 						delete gf;
 						return nullptr;
 					}
-
 
 					if (af.data_case() == WISE::GridProto::CwfgmAttributeFilter::kFile)
 					{

--- a/WISE_Project/cpp/ReplaceGridFilter.cpp
+++ b/WISE_Project/cpp/ReplaceGridFilter.cpp
@@ -474,11 +474,11 @@ bool Project::PolyReplaceGridFilter::ClearAllPolygons()
 }
 
 
-HRESULT Project::PolyReplaceGridFilter::ImportPolygons(const std::string &file_name, const std::vector<std::string> *pd)
+HRESULT Project::PolyReplaceGridFilter::ImportPolygons(const std::filesystem::path &file_name, const std::vector<std::string_view> &permissible_drivers)
 {
 	auto vf = boost::dynamic_pointer_cast<CCWFGM_PolyReplaceGridFilter>(m_filter);
 	if (vf)
-		return vf->ImportPolygons(file_name, pd);
+		return vf->ImportPolygons(file_name, permissible_drivers);
 	return E_FAIL;
 }
 
@@ -492,7 +492,7 @@ HRESULT Project::PolyReplaceGridFilter::ImportPolygonsWFS(const std::string &ser
 }
 
 
-HRESULT Project::PolyReplaceGridFilter::ExportPolygons(const std::string &driver_name, const std::string &export_projection, const std::string &file_name)
+HRESULT Project::PolyReplaceGridFilter::ExportPolygons(std::string_view driver_name, const std::string& export_projection, const std::filesystem::path &file_name)
 {
 	auto vf = boost::dynamic_pointer_cast<CCWFGM_PolyReplaceGridFilter>(m_filter);
 	if (vf)

--- a/WISE_Project/cpp/Scenario.cpp
+++ b/WISE_Project/cpp/Scenario.cpp
@@ -1384,7 +1384,7 @@ bool Project::Scenario::duplicateFilterList(const Scenario &s)
 
 
 HRESULT Project::Scenario::ExportFireFronts(Fire* fires, WTime& start_time, WTime& end_time, VectorExportOptions* options, USHORT flags,
-	const std::string& driver_name, const std::string& export_projection, const std::string& file_name,
+	std::string_view driver_name, const std::string& export_projection, const std::filesystem::path& file_name,
 	const TCHAR* fgm_name, const TCHAR* prometheus_version, ::UnitConvert::STORAGE_UNIT perimeter_units,
 	::UnitConvert::STORAGE_UNIT area_units, ::UnitConversion* uc, const USHORT child_flags) const
 {
@@ -1480,7 +1480,7 @@ HRESULT Project::Scenario::ExportFireFronts(Fire* fires, WTime& start_time, WTim
 	{
 		rules.AddStatistic(_T("DATE"), CWFGM_FIRE_STAT_DATE, 0);
 		rules.AddStatistic(_T("TIME"), CWFGM_FIRE_STAT_TIME, 0);
-		if ((!_tcsicmp(driver_name.c_str(), _T("LIBKML"))) || (!_tcsicmp(driver_name.c_str(), _T("KML"))))
+		if ((!_tcsicmp(driver_name.data(), _T("LIBKML"))) || (!_tcsicmp(driver_name.data(), _T("KML"))))
 			rules.AddStatistic(_T("TIMESTAMP"), CWFGM_FIRE_STAT_DATETIME, 0);
 	}
 
@@ -1677,7 +1677,7 @@ HRESULT Project::Scenario::ExportFireFronts(Fire* fires, WTime& start_time, WTim
 
 
 HRESULT Project::Scenario::ExportCriticalPath(const Asset* a, const std::uint32_t index, const std::uint16_t flags,
-	const char* driver_name, const char* export_projection, const char* file_path) const {
+	std::string_view driver_name, std::string& export_projection, const std::filesystem::path& file_path) const {
 	ScenarioExportRules rules;
 
 	rules.AddAttributeString(_T("SCENARIO"), m_name.c_str());

--- a/WISE_Project/cpp/WeatherGridFilter.cpp
+++ b/WISE_Project/cpp/WeatherGridFilter.cpp
@@ -120,10 +120,10 @@ auto Project::CWeatherPolyFilter::Duplicate(std::function<GridFilter*(void)> con
 }
 
 
-HRESULT Project::CWeatherPolyFilter::ImportPolygons(const std::string &file_name, const std::vector<std::string> *pd)
+HRESULT Project::CWeatherPolyFilter::ImportPolygons(const std::filesystem::path &file_name, const std::vector<std::string_view> &permissible_drivers)
 {
 	auto vf = boost::dynamic_pointer_cast<CCWFGM_WeatherGridFilter>(m_filter);
-	return vf->ImportPolygons(file_name, pd);
+	return vf->ImportPolygons(file_name, permissible_drivers);
 }
 
 
@@ -134,7 +134,7 @@ HRESULT Project::CWeatherPolyFilter::ImportPolygonsWFS(const std::string &server
 }
 
 
-HRESULT Project::CWeatherPolyFilter::ExportPolygons(const std::string &driver_name, const std::string &export_projection, const std::string &file_name)
+HRESULT Project::CWeatherPolyFilter::ExportPolygons(std::string_view driver_name, const std::string &export_projection, const std::filesystem::path &file_name)
 {
 	auto vf = boost::dynamic_pointer_cast<CCWFGM_WeatherGridFilter>(m_filter);
 	return vf->ExportPolygons(driver_name, export_projection, file_name);

--- a/WISE_Project/cpp/assetcollection.cpp
+++ b/WISE_Project/cpp/assetcollection.cpp
@@ -104,16 +104,16 @@ void Project::Asset::SetPolyLineWidth(double width)
 }
 
 
-HRESULT Project::Asset::ImportPolylines(const std::string& file_name, const std::vector<std::string>& pd)
+HRESULT Project::Asset::ImportPolylines(const std::filesystem::path& file_name, const std::vector<std::string_view>& pd)
 {
 	auto vf = boost::dynamic_pointer_cast<CCWFGM_Asset>(m_filter);
 	if (vf)
-		return vf->ImportPolylines(file_name, &pd);
+		return vf->ImportPolylines(file_name, pd);
 	return ERROR_INVALID_STATE;
 }
 
 
-HRESULT Project::Asset::ExportPolylines(const std::string& driver_name, const std::string& export_projection, const std::string& file_name)
+HRESULT Project::Asset::ExportPolylines(std::string_view driver_name, const std::string& export_projection, const std::filesystem::path& file_name)
 {
 	auto vf = boost::dynamic_pointer_cast<CCWFGM_Asset>(m_filter);
 	if (vf)

--- a/WISE_Project/cpp/targetcollection.cpp
+++ b/WISE_Project/cpp/targetcollection.cpp
@@ -75,13 +75,13 @@ void Project::Target::Clone(boost::intrusive_ptr<ICWFGM_Target>* target) const
 }
 
 
-HRESULT Project::Target::ImportPointSet(const std::string& file_name, const std::vector<std::string>& pd) {
+HRESULT Project::Target::ImportPointSet(const std::filesystem::path& file_name, const std::vector<std::string_view>& pd) {
 	auto vf = boost::dynamic_pointer_cast<CCWFGM_Target>(m_target);
-	return vf->ImportPointSet(file_name.c_str(), &pd);
+	return vf->ImportPointSet(file_name, pd);
 }
 
 
-HRESULT Project::Target::ExportPointSet(const std::string& driver_name, const std::string& export_projection, const std::string& file_name) {
+HRESULT Project::Target::ExportPointSet(std::string_view driver_name, const std::string& export_projection, const std::filesystem::path& file_name) {
 	auto vf = boost::dynamic_pointer_cast<CCWFGM_Target>(m_target);
 	return vf->ExportPointSet(driver_name, export_projection, file_name);
 }

--- a/WISE_Project/cpp/vectorcollection.cpp
+++ b/WISE_Project/cpp/vectorcollection.cpp
@@ -142,7 +142,7 @@ void Project::StaticVector::SetPolyLineWidth(double width)
 }
 
 
-HRESULT Project::StaticVector::ImportPolylines(const std::string &file_name, const std::vector<std::string> *pd)
+HRESULT Project::StaticVector::ImportPolylines(const std::filesystem::path &file_name, const std::vector<std::string_view> &pd)
 {
 	auto vf = boost::dynamic_pointer_cast<CCWFGM_VectorFilter>(m_filter);
 	return vf->ImportPolylines(file_name, pd);
@@ -156,7 +156,7 @@ HRESULT Project::StaticVector::ImportPolylinesWFS(const std::string &server, con
 }
 
 
-HRESULT Project::StaticVector::ExportPolylines(const std::string &driver_name, const std::string &export_projection, const std::string &file_name)
+HRESULT Project::StaticVector::ExportPolylines(std::string_view driver_name, const std::string &export_projection, const std::filesystem::path &file_name)
 {
 	auto vf = boost::dynamic_pointer_cast<CCWFGM_VectorFilter>(m_filter);
 	return vf->ExportPolylines(driver_name, export_projection, file_name);

--- a/WISE_Project/include/CWFGMProject.h
+++ b/WISE_Project/include/CWFGMProject.h
@@ -212,8 +212,7 @@ protected:
 
 public:
 	boost::intrusive_ptr<CCWFGM_LayerManager>	m_layerManager;
-	static const char *m_permissibleVectorReadDrivers[];
-	static std::vector<std::string> m_permissibleVectorReadDriversSA;
+	static std::vector<std::string_view> m_permissibleVectorReadDriversSA;
 	static std::int32_t		m_managedMode;
 
 	std::string				m_comments;

--- a/WISE_Project/include/PermissibleVectorReadDrivers.h
+++ b/WISE_Project/include/PermissibleVectorReadDrivers.h
@@ -18,5 +18,5 @@
 
 #pragma once
 
-#define GDAL_READ_DRIVERS_LENGTH 6
-#define GDAL_READ_DRIVERS { "ESRI Shapefile", "GPKG", "LIBKML", "KML", "ESRIJSON", "GeoJSON",  }
+#define GDAL_READ_DRIVERS { "ESRI Shapefile", "GPKG", "LIBKML", "KML", "ESRIJSON", "GeoJSON"  }
+static const std::vector<std::string_view> permissibleVectorReadDrivers = GDAL_READ_DRIVERS;

--- a/WISE_Project/include/ReplaceGridFilter.h
+++ b/WISE_Project/include/ReplaceGridFilter.h
@@ -125,9 +125,9 @@ namespace Project
 		double Area() override;
 		bool ClearAllPolygons();
 
-		HRESULT ImportPolygons(const std::string &file_name, const std::vector<std::string> *pd);
+		HRESULT ImportPolygons(const std::filesystem::path &file_name, const std::vector<std::string_view> &permissible_drivers);
 		HRESULT ImportPolygonsWFS(const std::string &server, const std::string &layer, const std::string &uid, const std::string &pwd);
-		HRESULT ExportPolygons(const std::string &driver_name, const std::string &export_projection, const std::string &file_name);
+		HRESULT ExportPolygons(std::string_view driver_name, const std::string &export_projection, const std::filesystem::path &file_name);
 
 		HRESULT SetRelationship(ICWFGM_Fuel *from_fuel, UCHAR from_index, ICWFGM_Fuel *to_fuel) override;
 		HRESULT GetRelationship(ICWFGM_Fuel **from_fuel, UCHAR *from_index, ICWFGM_Fuel **to_fuel) const override;

--- a/WISE_Project/include/ScenarioCollection.h
+++ b/WISE_Project/include/ScenarioCollection.h
@@ -247,11 +247,11 @@ namespace Project
 		bool RemoveFilter(GridFilter *filter);
 
 		HRESULT ExportFireFronts(Fire *fires, HSS_Time::WTime &start_time, HSS_Time::WTime &end_time, VectorExportOptions *options, USHORT flags,
-			const std::string &driver_name, const std::string &export_projection, const std::string &file_name,
+			std::string_view driver_name, const std::string &export_projection, const std::filesystem::path &file_name,
 			const TCHAR *fgm_name, const TCHAR *prometheus_version, ::UnitConvert::STORAGE_UNIT perimeter_units,
 			::UnitConvert::STORAGE_UNIT area_units, ::UnitConversion *uc = nullptr, const USHORT child_flags = 0x0001) const;
 		HRESULT ExportCriticalPath(const Asset* a, const std::uint32_t index, const std::uint16_t flags,
-			const char* driver_name, const char* export_projection, const char* file_path) const;
+			std::string_view driver_name, std::string& export_projection, const std::filesystem::path& file_path) const;
 		HRESULT BuildCriticalPath(const Asset* a, const std::uint32_t index, const std::uint16_t flags, MinListTempl<CriticalPath>& polyset) const;
 
 		ULONG GetFilterCount() const { return m_filterList.GetCount(); };

--- a/WISE_Project/include/StdFireCollection.h
+++ b/WISE_Project/include/StdFireCollection.h
@@ -77,9 +77,9 @@ namespace Project
 									  return CWFGM_FIRE_IGNITION_UNDEFINED;
 									};
 
-		HRESULT ImportIgnition(const std::string &file_name, const std::vector<std::string> *pd);
+		HRESULT ImportIgnition(const std::filesystem::path &file_name, const std::vector<std::string_view> &permissible_drivers);
 		HRESULT ImportIgnitionWFS(const std::string &server, const std::string &layer, const std::string &uid, const std::string &pwd);
-		HRESULT ExportIgnition(const std::string &driver_name, const std::string &export_projection, const std::string &file_name);
+		HRESULT ExportIgnition(std::string_view driver_name, const std::string &export_projection, const std::filesystem::path &file_name);
 		void ExportBasicInfo(FILE *fp);
 
 		std::string	m_name,			// name for the CWFGM fire object

--- a/WISE_Project/include/WeatherGridFilter.h
+++ b/WISE_Project/include/WeatherGridFilter.h
@@ -142,9 +142,9 @@ namespace Project
 		void SetWD_Operation(std::uint16_t op);
 		void SetWS_Operation(std::uint16_t op);
 
-		HRESULT ImportPolygons(const std::string &file_name, const std::vector<std::string> *pd);
+		HRESULT ImportPolygons(const std::filesystem::path &file_name, const std::vector<std::string_view> &permissible_drivers);
 		HRESULT ImportPolygonsWFS(const std::string &server, const std::string &layer, const std::string &uid, const std::string &pwd);
-		HRESULT ExportPolygons(const std::string &driver_name, const std::string &export_projection, const std::string &file_name);
+		HRESULT ExportPolygons(std::string_view driver_name, const std::string &export_projection, const std::filesystem::path &file_name);
 
 		void SetLineWidth(ULONG Width)						{ m_lineWidth = Width; };
 		ULONG GetLineWidth()								{ return m_lineWidth; };

--- a/WISE_Project/include/assetcollection.h
+++ b/WISE_Project/include/assetcollection.h
@@ -104,8 +104,8 @@ namespace Project
 		virtual double GetPolyLineWidth();			// in grid units
 		virtual void SetPolyLineWidth(double width);		// in grid units
 
-		HRESULT ImportPolylines(const std::string& file_name, const std::vector<std::string>& pd);
-		HRESULT ExportPolylines(const std::string& driver_name, const std::string& export_projection, const std::string& file_name);
+		HRESULT ImportPolylines(const std::filesystem::path& file_name, const std::vector<std::string_view>& pd);
+		HRESULT ExportPolylines(std::string_view driver_name, const std::string& export_projection, const std::filesystem::path& file_name);
 
 	public:
 		virtual std::int32_t serialVersionUid(const SerializeProtoOptions& options) const noexcept override;

--- a/WISE_Project/include/targetcollection.h
+++ b/WISE_Project/include/targetcollection.h
@@ -93,8 +93,8 @@ namespace Project
 		XY_Point* GetTargetSet(ULONG index, XY_Point* points, std::uint32_t* size);
 		BOOL ClearPointSets();
 
-		HRESULT ImportPointSet(const std::string& file_name, const std::vector<std::string>& pd);
-		HRESULT ExportPointSet(const std::string& driver_name, const std::string& export_projection, const std::string& file_name);
+		HRESULT ImportPointSet(const std::filesystem::path& file_name, const std::vector<std::string_view>& pd);
+		HRESULT ExportPointSet(std::string_view driver_name, const std::string& export_projection, const std::filesystem::path& file_name);
 
 	protected:
 		virtual void Clone(boost::intrusive_ptr<ICWFGM_Target>* /*target*/) const;

--- a/WISE_Project/include/vectorcollection.h
+++ b/WISE_Project/include/vectorcollection.h
@@ -127,9 +127,9 @@ namespace Project
 		virtual double GetPolyLineWidth();			// in grid units
 		virtual void SetPolyLineWidth(double width);		// in grid units
 
-		HRESULT ImportPolylines(const std::string &file_name, const std::vector<std::string> *pd);
+		HRESULT ImportPolylines(const std::filesystem::path &file_name, const std::vector<std::string_view> &pd);
 		HRESULT ImportPolylinesWFS(const std::string &server, const std::string &layer, const std::string &uid, const std::string &pwd);
-		HRESULT ExportPolylines(const std::string &driver_name, const std::string &export_projection, const std::string &file_name);
+		HRESULT ExportPolylines(std::string_view driver_name, const std::string &export_projection, const std::filesystem::path &file_name);
 
 	public:
 		virtual std::int32_t serialVersionUid(const SerializeProtoOptions& options) const noexcept override;


### PR DESCRIPTION
The list used to be a raw array that relied on having a null at the end, change to a std::vector.