### PR TITLE
Pin the GSL version

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -93,6 +93,7 @@ jobs:
         repository: microsoft/GSL
         path: GSL
         token: ${{ secrets.WISE_PAT }}
+        ref: refs/tags/v4.0.0
     - uses: actions/checkout@v3
       with:
         repository: eclipse/paho.mqtt.c


### PR DESCRIPTION
Force the GSL library to build from tag v4.0.0 instead of always using the repository head.

For #53